### PR TITLE
Fix: TopNavigation 스크롤 수정

### DIFF
--- a/src/components/Swiper/Swiper.tsx
+++ b/src/components/Swiper/Swiper.tsx
@@ -13,16 +13,16 @@ const Swiper = forwardRef(function Div(
 
   const handleSlideChange = (e: any) => {
     let newSwiper = e.activeIndex;
-    index.setCurrentIndex(newSwiper);
+    index.setSwiperIndex(newSwiper);
   };
   const handleTouchStart = (e: any) => {
     touch.setTouch(true);
   };
   const handleTouchMove = (e: any) => {
     if (
-      !e?.swipeDirection ||
-      (e?.swipeDirection === "next" && index.currentIndex === length - 1) ||
-      (e?.swipeDirection === "prev" && index.currentIndex === 0)
+      e?.swipeDirection === undefined ||
+      (e?.swipeDirection === "next" && index.swiperIndex === length - 1) ||
+      (e?.swipeDirection === "prev" && index.swiperIndex === 0)
     ) {
       touch.setTouch(false);
     } else {
@@ -36,8 +36,8 @@ const Swiper = forwardRef(function Div(
   return (
     <OriginalSwiper
       spaceBetween={gap}
-      allowSlidePrev={index.currentIndex !== 0}
-      allowSlideNext={index.currentIndex !== length - 1}
+      allowSlidePrev={index.swiperIndex !== 0}
+      allowSlideNext={index.swiperIndex !== length - 1}
       onSlideChange={handleSlideChange}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}

--- a/src/components/TopNavigation/InnerTopNavigation.tsx
+++ b/src/components/TopNavigation/InnerTopNavigation.tsx
@@ -1,0 +1,43 @@
+import React, { forwardRef, useEffect } from "react";
+import { useAppSelector } from "hooks/useReduxHooks";
+
+import { ScrollArea } from "components/core";
+import { globalValue } from "constants/globalValue";
+
+const InnerTopNavigation = forwardRef(function Div(
+  {
+    scrollRef,
+    innerScrollRef,
+    padding,
+    bottomHeight,
+    direction,
+    children,
+  }: any,
+  ref: any
+) {
+  const { display } = useAppSelector((state) => state.global);
+
+  const handleTouchMove = () => {
+    if (
+      direction === "up" &&
+      scrollRef?.current?.scrollTop >= 332 &&
+      innerScrollRef?.current?.scrollTop === 0
+    ) {
+      scrollRef.current!.scrollTo({ top: 332 });
+    }
+  };
+
+  return (
+    <ScrollArea
+      veiwportRef={innerScrollRef}
+      ph={padding}
+      h={display.height - bottomHeight - globalValue.BOTTOM_NAVIGATION_HEIGHT}
+      style={{ overflow: "hidden" }}
+      onTouchMove={handleTouchMove}
+    >
+      {children}
+    </ScrollArea>
+  );
+});
+
+export default InnerTopNavigation;

--- a/src/components/TopNavigation/ScrollTopNavigation.tsx
+++ b/src/components/TopNavigation/ScrollTopNavigation.tsx
@@ -1,73 +1,58 @@
 import React, { forwardRef, useEffect } from "react";
-import { makeStyles } from "@material-ui/core";
-import { Tab, Tabs } from "@mui/material";
-import { styled } from "@mui/material/styles";
-import SwipeableViews from "react-swipeable-views";
 import { useAppSelector } from "hooks/useReduxHooks";
 
-import { colors } from "constants/colors";
-import { Box, Divider, ScrollArea, Text } from "components/core";
+import { Box, ScrollArea } from "components/core";
 import { globalValue } from "constants/globalValue";
 
 const ScrollTopNavigation = forwardRef(function Div(
-  {
-    refs,
-    height,
-    padding,
-    gap,
-    color = "N100",
-    index,
-    touch,
-    keywordDatas,
-    children,
-  }: any,
+  { refs, index, Y, direction, title, children }: any,
   ref: any
 ) {
   const { display } = useAppSelector((state) => state.global);
 
   const handleTouchStart = (e: any) => {
-    // setStartY(e?.changedTouches[0].clientY);
-    // setStartY1(scrollRef1?.current?.scrollTop);
-    // setStartY2(scrollRef2?.current?.scrollTop);
+    let scrollTop = [];
+    for (let i = 1; i < refs?.length; i++) {
+      scrollTop.push(refs?.[i]?.current?.scrollTop);
+    }
+    Y.setStartY([e?.changedTouches[0].clientY, ...scrollTop]);
   };
   const handleTouchMove = (e: any) => {
     const newMoveY = e?.changedTouches?.[0]?.clientY;
-    // if (newMoveY - startY < 0) setDirection("down");
-    // else setDirection("up");
+    if (newMoveY - Y.startY[0] < 0) direction.setDirection("down");
+    else direction.setDirection("up");
   };
 
   const handleScroll = ({ scrollY }: { scrollX: number; scrollY: number }) => {
     if (scrollY < 332) {
-      refs?.scrollRef1.current!.style.setProperty("overflow-y", `hidden`);
-      refs?.scrollRef2.current!.style.setProperty("overflow-y", `hidden`);
+      for (let i = 1; i < refs?.length; i++) {
+        refs?.[i].current!.style.setProperty("overflow-y", `hidden`);
+      }
     } else if (scrollY >= 332) {
-      refs?.scrollRef1.current!.style.setProperty("overflow-y", `scroll`);
-      refs?.scrollRef2.current!.style.setProperty("overflow-y", `scroll`);
+      for (let i = 1; i < refs?.length; i++) {
+        refs?.[i].current!.style.setProperty("overflow-y", `scroll`);
+      }
 
-      //   if (direction === "down") {
-      //     if (currentIndex === 0 && startY1 === 0) {
-      //       refs?.scrollRef1.current!.scrollTo({
-      //         top: scrollY - 332,
-      //       });
-      //     } else if (startY2 === 0) {
-      //       refs?.scrollRef2.current!.scrollTo({
-      //         top: scrollY - 332,
-      //       });
-      //     }
-      //   }
+      if (direction.direction === "down") {
+        if (Y.startY[index.currentIndex + 1] === 0) {
+          refs?.[index.currentIndex + 1].current!.scrollTo({
+            top: scrollY - 332,
+          });
+        }
+      }
     }
 
-    // if (scrollY > 10) {
-    //   setTitleChange(true);
-    // } else {
-    //   setTitleChange(false);
-    // }
+    if (scrollY > 10) {
+      title.setTitleChange(true);
+    } else {
+      title.setTitleChange(false);
+    }
   };
 
   return (
     <ScrollArea
-      veiwportRef={refs?.scrollRef}
-      h={height - 50 - globalValue.BOTTOM_NAVIGATION_HEIGHT}
+      veiwportRef={refs?.[0]}
+      h={display.height - 50 - globalValue.BOTTOM_NAVIGATION_HEIGHT}
       pos="absolute"
       top={50}
       onTouchStart={handleTouchStart}

--- a/src/components/TopNavigation/ScrollTopNavigation.tsx
+++ b/src/components/TopNavigation/ScrollTopNavigation.tsx
@@ -1,0 +1,83 @@
+import React, { forwardRef, useEffect } from "react";
+import { makeStyles } from "@material-ui/core";
+import { Tab, Tabs } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import SwipeableViews from "react-swipeable-views";
+import { useAppSelector } from "hooks/useReduxHooks";
+
+import { colors } from "constants/colors";
+import { Box, Divider, ScrollArea, Text } from "components/core";
+import { globalValue } from "constants/globalValue";
+
+const ScrollTopNavigation = forwardRef(function Div(
+  {
+    refs,
+    height,
+    padding,
+    gap,
+    color = "N100",
+    index,
+    touch,
+    keywordDatas,
+    children,
+  }: any,
+  ref: any
+) {
+  const { display } = useAppSelector((state) => state.global);
+
+  const handleTouchStart = (e: any) => {
+    // setStartY(e?.changedTouches[0].clientY);
+    // setStartY1(scrollRef1?.current?.scrollTop);
+    // setStartY2(scrollRef2?.current?.scrollTop);
+  };
+  const handleTouchMove = (e: any) => {
+    const newMoveY = e?.changedTouches?.[0]?.clientY;
+    // if (newMoveY - startY < 0) setDirection("down");
+    // else setDirection("up");
+  };
+
+  const handleScroll = ({ scrollY }: { scrollX: number; scrollY: number }) => {
+    if (scrollY < 332) {
+      refs?.scrollRef1.current!.style.setProperty("overflow-y", `hidden`);
+      refs?.scrollRef2.current!.style.setProperty("overflow-y", `hidden`);
+    } else if (scrollY >= 332) {
+      refs?.scrollRef1.current!.style.setProperty("overflow-y", `scroll`);
+      refs?.scrollRef2.current!.style.setProperty("overflow-y", `scroll`);
+
+      //   if (direction === "down") {
+      //     if (currentIndex === 0 && startY1 === 0) {
+      //       refs?.scrollRef1.current!.scrollTo({
+      //         top: scrollY - 332,
+      //       });
+      //     } else if (startY2 === 0) {
+      //       refs?.scrollRef2.current!.scrollTo({
+      //         top: scrollY - 332,
+      //       });
+      //     }
+      //   }
+    }
+
+    // if (scrollY > 10) {
+    //   setTitleChange(true);
+    // } else {
+    //   setTitleChange(false);
+    // }
+  };
+
+  return (
+    <ScrollArea
+      veiwportRef={refs?.scrollRef}
+      h={height - 50 - globalValue.BOTTOM_NAVIGATION_HEIGHT}
+      pos="absolute"
+      top={50}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onScroll={handleScroll}
+    >
+      {children}
+      <Box h={1000} />
+    </ScrollArea>
+  );
+});
+
+export default ScrollTopNavigation;

--- a/src/components/TopNavigation/TopNavigation.tsx
+++ b/src/components/TopNavigation/TopNavigation.tsx
@@ -48,8 +48,8 @@ const TopNavigation = forwardRef(function Div(
   const { display } = useAppSelector((state) => state.global);
   const classes = useStyles({ height, padding, gap });
 
-  const handleChange = (_: React.SyntheticEvent, newValue: number) => {
-    index.setCurrentIndex(newValue);
+  const handleChange = (_: React.SyntheticEvent, newIndex: number) => {
+    index.setCurrentIndex(newIndex);
   };
   const handleChangeIndex = (newIndex: number) => {
     index.setCurrentIndex(newIndex);
@@ -98,7 +98,7 @@ const TopNavigation = forwardRef(function Div(
       <SwipeableViews
         index={index.currentIndex}
         onChangeIndex={handleChangeIndex}
-        disabled={touch.touch && index.currentIndex === 0}
+        disabled={touch.touch}
       >
         {children}
       </SwipeableViews>

--- a/src/components/TopNavigation/index.ts
+++ b/src/components/TopNavigation/index.ts
@@ -1,1 +1,5 @@
-export { default } from "./TopNavigation";
+import ScrollTopNavigation from "./ScrollTopNavigation";
+import TopNavigation from "./TopNavigation";
+
+export { ScrollTopNavigation };
+export { TopNavigation };

--- a/src/components/TopNavigation/index.ts
+++ b/src/components/TopNavigation/index.ts
@@ -1,5 +1,7 @@
 import ScrollTopNavigation from "./ScrollTopNavigation";
 import TopNavigation from "./TopNavigation";
+import InnerTopNavigation from "./InnerTopNavigation";
 
 export { ScrollTopNavigation };
 export { TopNavigation };
+export { InnerTopNavigation };

--- a/src/components/core/ScrollArea/ScrollArea.tsx
+++ b/src/components/core/ScrollArea/ScrollArea.tsx
@@ -4,6 +4,11 @@ import { ComponentsProps } from "models/componentsModal";
 import styled from "@emotion/styled";
 import { coreStyles } from "../coreStyles";
 
+export interface onScrollProps {
+  scrollX: number;
+  scrollY: number;
+}
+
 type ScrollAreaProps = ComponentsProps & {
   // scroll?: "xy" | "x" | "y" | undefined;
   scroll?: boolean;

--- a/src/components/custom/index.ts
+++ b/src/components/custom/index.ts
@@ -1,7 +1,7 @@
 import Alert from "../Alert";
 import BottomNavigation from "../BottomNavigation";
-import TopNavigation from "../TopNavigation";
+// import TopNavigation from "../TopNavigation";
 import BottomSheet from "../BottomSheet";
 
 export { Alert };
-export { TopNavigation };
+// export { TopNavigation };

--- a/src/reducer/slices/index.ts
+++ b/src/reducer/slices/index.ts
@@ -13,6 +13,7 @@ import currIdxSlice from "./image/currIdxSlice";
 import menuTagSlice from "./image/menuTagSlice";
 import userSlice from "./user/userSlice";
 import recommendReviewSlice from "./review/recommendReviewSlice";
+import topNavigationSlice from "./topNativation/topNavigationSlice";
 
 const rootReducer = (state: any, action: PayloadAction<any>) => {
   switch (action.type) {
@@ -34,6 +35,7 @@ const rootReducer = (state: any, action: PayloadAction<any>) => {
         currIdx: currIdxSlice,
         review: reviewSlice,
         recommendReview: recommendReviewSlice,
+        topNavigation: topNavigationSlice,
         user: userSlice,
       });
       return combineReducer(state, action);

--- a/src/reducer/slices/topNativation/topNavigationSlice.ts
+++ b/src/reducer/slices/topNativation/topNavigationSlice.ts
@@ -1,0 +1,29 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+interface TopNavigationProps {
+  scrollRef: any;
+}
+
+const initialState: TopNavigationProps = {
+  scrollRef: null,
+};
+
+export const topNativationSlice = createSlice({
+  name: "topNavigation",
+  initialState,
+  reducers: {
+    initializeDefaultInfo: () => initialState,
+    initialScrollRef: (
+      state,
+      { payload }: { payload: { type: string; value: any } }
+    ) => {
+      const { value } = payload;
+      state.scrollRef = value;
+    },
+  },
+});
+
+export const { initializeDefaultInfo, initialScrollRef } =
+  topNativationSlice.actions;
+
+export default topNativationSlice.reducer;

--- a/src/view/Mypage/Mypage.tsx
+++ b/src/view/Mypage/Mypage.tsx
@@ -15,6 +15,7 @@ import { Box, Space, ScrollArea } from "components/core";
 import BottomNavigation from "components/BottomNavigation";
 import Setting from "components/Button/IconButton/Setting";
 import LoadingCircle from "components/Loading/LoadingCircle";
+import TopNavigation from "components/TopNavigation/TopNavigation";
 import Title from "components/Title";
 import Dots from "components/Button/IconButton/Dots";
 import BackArrow from "components/Button/IconButton/BackArrow";
@@ -23,7 +24,7 @@ import TasteBox from "./components/TasteBox";
 import ProfileInfo from "./components/ProfileInfo";
 import RecommendReviewCardContainer from "./components/RecommendReviewCardContainer";
 import ReviewCardContainer from "./components/ReviewCardContainer";
-import { ScrollTopNavigation, TopNavigation } from "components/TopNavigation";
+import { ScrollTopNavigation } from "components/TopNavigation";
 
 // 392 + 35 = 427
 
@@ -47,50 +48,10 @@ export default function Mypage() {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
 
   const [touch, setTouch] = useState(false);
-  const [startY, setStartY] = useState(0);
   const [direction, setDirection] = useState("none");
+  const [startY, setStartY] = useState([0, 0, 0]);
 
-  const [startY1, setStartY1] = useState(0);
-  const [startY2, setStartY2] = useState(0);
-  const handleTouchStart = (e: any) => {
-    setStartY(e?.changedTouches[0].clientY);
-    setStartY1(scrollRef1?.current?.scrollTop);
-    setStartY2(scrollRef2?.current?.scrollTop);
-  };
-  const handleTouchMove = (e: any) => {
-    const newMoveY = e?.changedTouches?.[0]?.clientY;
-    if (newMoveY - startY < 0) setDirection("down");
-    else setDirection("up");
-  };
-
-  const handleScroll = ({ scrollY }: { scrollX: number; scrollY: number }) => {
-    if (scrollY < 332) {
-      scrollRef1.current!.style.setProperty("overflow-y", `hidden`);
-      scrollRef2.current!.style.setProperty("overflow-y", `hidden`);
-    } else if (scrollY >= 332) {
-      scrollRef1.current!.style.setProperty("overflow-y", `scroll`);
-      scrollRef2.current!.style.setProperty("overflow-y", `scroll`);
-
-      if (direction === "down") {
-        if (currentIndex === 0 && startY1 === 0) {
-          scrollRef1.current!.scrollTo({
-            top: scrollY - 332,
-          });
-        } else if (startY2 === 0) {
-          scrollRef2.current!.scrollTo({
-            top: scrollY - 332,
-          });
-        }
-      }
-    }
-
-    if (scrollY > 10) {
-      setTitleChange(true);
-    } else {
-      setTitleChange(false);
-    }
-  };
-
+  //
   const { profileData, isLoadingProfile } = useGetProfile();
   const { recommendReviewDatas } = useGetRecommendReviews();
 
@@ -121,7 +82,13 @@ export default function Mypage() {
           animate={{ opacity: 1 }}
           transition={{ duration: 0.5 }}
         >
-          <ScrollTopNavigation>
+          <ScrollTopNavigation
+            refs={[scrollRef, scrollRef1, scrollRef2]}
+            index={{ currentIndex, setCurrentIndex }}
+            Y={{ startY, setStartY }}
+            direction={{ direction, setDirection }}
+            title={{ titleChange, setTitleChange }}
+          >
             {/* 332 */}
             <Box w={width} ph={20} bg="N0">
               <ProfileInfo mine={mine} profileData={profileData} />
@@ -143,18 +110,17 @@ export default function Mypage() {
               keywordDatas={["추천 베스트", "리뷰"]}
             >
               <RecommendReviewCardContainer
-                refs={{ scrollRef, scrollRef1, scrollRef2 }}
+                refs={[scrollRef, scrollRef1]}
                 mine={mine}
                 direction={direction}
                 touch={{ touch, setTouch }}
               />
               <ReviewCardContainer
-                refs={{ scrollRef, scrollRef1, scrollRef2 }}
+                refs={[scrollRef, scrollRef2]}
                 mine={mine}
                 direction={direction}
               />
             </TopNavigation>
-            <Box h={1000} />
           </ScrollTopNavigation>
         </motion.div>
       )}

--- a/src/view/Mypage/Mypage.tsx
+++ b/src/view/Mypage/Mypage.tsx
@@ -15,7 +15,6 @@ import { Box, Space, ScrollArea } from "components/core";
 import BottomNavigation from "components/BottomNavigation";
 import Setting from "components/Button/IconButton/Setting";
 import LoadingCircle from "components/Loading/LoadingCircle";
-import TopNavigation from "components/TopNavigation/TopNavigation";
 import Title from "components/Title";
 import Dots from "components/Button/IconButton/Dots";
 import BackArrow from "components/Button/IconButton/BackArrow";
@@ -24,6 +23,7 @@ import TasteBox from "./components/TasteBox";
 import ProfileInfo from "./components/ProfileInfo";
 import RecommendReviewCardContainer from "./components/RecommendReviewCardContainer";
 import ReviewCardContainer from "./components/ReviewCardContainer";
+import { ScrollTopNavigation, TopNavigation } from "components/TopNavigation";
 
 // 392 + 35 = 427
 
@@ -49,8 +49,13 @@ export default function Mypage() {
   const [touch, setTouch] = useState(false);
   const [startY, setStartY] = useState(0);
   const [direction, setDirection] = useState("none");
+
+  const [startY1, setStartY1] = useState(0);
+  const [startY2, setStartY2] = useState(0);
   const handleTouchStart = (e: any) => {
     setStartY(e?.changedTouches[0].clientY);
+    setStartY1(scrollRef1?.current?.scrollTop);
+    setStartY2(scrollRef2?.current?.scrollTop);
   };
   const handleTouchMove = (e: any) => {
     const newMoveY = e?.changedTouches?.[0]?.clientY;
@@ -59,25 +64,19 @@ export default function Mypage() {
   };
 
   const handleScroll = ({ scrollY }: { scrollX: number; scrollY: number }) => {
-    if (direction === "up" && scrollRef1?.current?.scrollTop <= 0) {
-      // scrollRef2.current!.scrollTo({ top: 0 });
-      scrollRef1.current!.style.setProperty("overflow", `hidden`);
-      scrollRef2.current!.style.setProperty("overflow", `hidden`);
-    }
-    //아래로 내리는 경우
-    else if (direction === "down") {
-      if (scrollY < 332) {
-        scrollRef1.current!.style.setProperty("overflow", `hidden`);
-        scrollRef2.current!.style.setProperty("overflow", `hidden`);
-      } else {
-        scrollRef1.current!.style.setProperty("overflow", `auto`);
-        scrollRef2.current!.style.setProperty("overflow", `auto`);
+    if (scrollY < 332) {
+      scrollRef1.current!.style.setProperty("overflow-y", `hidden`);
+      scrollRef2.current!.style.setProperty("overflow-y", `hidden`);
+    } else if (scrollY >= 332) {
+      scrollRef1.current!.style.setProperty("overflow-y", `scroll`);
+      scrollRef2.current!.style.setProperty("overflow-y", `scroll`);
 
-        if (currentIndex === 0) {
+      if (direction === "down") {
+        if (currentIndex === 0 && startY1 === 0) {
           scrollRef1.current!.scrollTo({
             top: scrollY - 332,
           });
-        } else {
+        } else if (startY2 === 0) {
           scrollRef2.current!.scrollTo({
             top: scrollY - 332,
           });
@@ -122,15 +121,7 @@ export default function Mypage() {
           animate={{ opacity: 1 }}
           transition={{ duration: 0.5 }}
         >
-          <ScrollArea
-            veiwportRef={scrollRef}
-            h={height - 50 - globalValue.BOTTOM_NAVIGATION_HEIGHT}
-            pos="absolute"
-            top={50}
-            onTouchStart={handleTouchStart}
-            onTouchMove={handleTouchMove}
-            onScroll={handleScroll}
-          >
+          <ScrollTopNavigation>
             {/* 332 */}
             <Box w={width} ph={20} bg="N0">
               <ProfileInfo mine={mine} profileData={profileData} />
@@ -164,7 +155,7 @@ export default function Mypage() {
               />
             </TopNavigation>
             <Box h={1000} />
-          </ScrollArea>
+          </ScrollTopNavigation>
         </motion.div>
       )}
       <Title

--- a/src/view/Mypage/Mypage.tsx
+++ b/src/view/Mypage/Mypage.tsx
@@ -15,7 +15,7 @@ import { Box, Space, ScrollArea } from "components/core";
 import BottomNavigation from "components/BottomNavigation";
 import Setting from "components/Button/IconButton/Setting";
 import LoadingCircle from "components/Loading/LoadingCircle";
-import TopNavigation from "components/TopNavigation/TopNavigation";
+import { TopNavigation } from "components/TopNavigation";
 import Title from "components/Title";
 import Dots from "components/Button/IconButton/Dots";
 import BackArrow from "components/Button/IconButton/BackArrow";

--- a/src/view/Mypage/components/RecommandSwiper.tsx
+++ b/src/view/Mypage/components/RecommandSwiper.tsx
@@ -30,7 +30,7 @@ const RecommandSwiper = ({
   touch,
 }: RecommandSwiperProps) => {
   const router = useRouter();
-  const [currentIndex, setCurrentIndex] = useState<number>(0);
+  const [swiperIndex, setSwiperIndex] = useState<number>(0);
 
   const clickReviewDetail = (id: number) => {
     router.push({ pathname: Route.REVIEW_DETAIL(), query: { id } });
@@ -43,7 +43,7 @@ const RecommandSwiper = ({
     <>
       <Space h={20} />
       <Swiper
-        index={{ currentIndex, setCurrentIndex }}
+        index={{ swiperIndex, setSwiperIndex }}
         touch={touch}
         length={recommendReviewDatas?.length}
       >
@@ -107,7 +107,7 @@ const RecommandSwiper = ({
       <Flex mb={30} justify="center">
         <Flex gap={4}>
           {recommendReviewDatas?.map((_: any, idx: number) => {
-            return <Index key={idx} act={currentIndex === idx} />;
+            return <Index key={idx} act={swiperIndex === idx} />;
           })}
         </Flex>
       </Flex>

--- a/src/view/Mypage/components/RecommendReviewCardContainer.tsx
+++ b/src/view/Mypage/components/RecommendReviewCardContainer.tsx
@@ -5,6 +5,7 @@ import { globalValue } from "constants/globalValue";
 import useGetRecommendReviews from "hooks/queries/mypage/useGetRecommendReviews";
 import RecommandSwiper from "./RecommandSwiper";
 import { ScrollArea } from "components/core";
+import { onScrollProps } from "components/core/ScrollArea/ScrollArea";
 
 interface RecommendReviewCardContainerProps {
   refs?: any;
@@ -33,13 +34,13 @@ const RecommendReviewCardContainer = ({
       onTouchMove={() => {
         if (
           direction === "up" &&
-          refs?.scrollRef1?.current?.scrollTop === 0 &&
-          refs?.scrollRef?.current?.scrollTop > 332
+          refs?.scrollRef?.current?.scrollTop >= 332 &&
+          refs?.scrollRef1?.current?.scrollTop === 0
         ) {
           refs?.scrollRef.current!.scrollTo({ top: 332 });
         }
       }}
-      // onScroll={(e: any) => {
+      // onScroll={({ scrollY }: onScrollProps) => {
       //   // e.target.scrollTop
       // }}
     >

--- a/src/view/Mypage/components/RecommendReviewCardContainer.tsx
+++ b/src/view/Mypage/components/RecommendReviewCardContainer.tsx
@@ -6,6 +6,7 @@ import useGetRecommendReviews from "hooks/queries/mypage/useGetRecommendReviews"
 import RecommandSwiper from "./RecommandSwiper";
 import { ScrollArea } from "components/core";
 import { onScrollProps } from "components/core/ScrollArea/ScrollArea";
+import { InnerTopNavigation } from "components/TopNavigation";
 
 interface RecommendReviewCardContainerProps {
   refs?: any;
@@ -20,36 +21,22 @@ const RecommendReviewCardContainer = ({
   direction,
   touch,
 }: RecommendReviewCardContainerProps) => {
-  const { display } = useAppSelector((state) => state.global);
   const { recommendReviewDatas } = useGetRecommendReviews();
 
   return (
-    <ScrollArea
-      veiwportRef={refs?.scrollRef1}
-      ph={20}
-      h={
-        display.height - (mine ? 85 : 35) - globalValue.BOTTOM_NAVIGATION_HEIGHT
-      }
-      style={{ overflow: "hidden" }}
-      onTouchMove={() => {
-        if (
-          direction === "up" &&
-          refs?.scrollRef?.current?.scrollTop >= 332 &&
-          refs?.scrollRef1?.current?.scrollTop === 0
-        ) {
-          refs?.scrollRef.current!.scrollTo({ top: 332 });
-        }
-      }}
-      // onScroll={({ scrollY }: onScrollProps) => {
-      //   // e.target.scrollTop
-      // }}
+    <InnerTopNavigation
+      scrollRef={refs?.[0]}
+      innerScrollRef={refs?.[1]}
+      padding={20}
+      bottomHeight={mine ? 85 : 35}
+      direction={direction}
     >
       <RecommandSwiper
         recommendReviewDatas={recommendReviewDatas}
         mine={mine}
         touch={touch}
       />
-    </ScrollArea>
+    </InnerTopNavigation>
   );
 };
 

--- a/src/view/Mypage/components/ReviewCardContainer.tsx
+++ b/src/view/Mypage/components/ReviewCardContainer.tsx
@@ -6,6 +6,7 @@ import { globalValue } from "constants/globalValue";
 import useGetReviews from "hooks/queries/user/useGetReviews";
 import { useAppSelector } from "hooks/useReduxHooks";
 import ReviewList from "./ReviewList";
+import { InnerTopNavigation } from "components/TopNavigation";
 
 interface ReviewCardContainerProps {
   refs?: any;
@@ -18,38 +19,16 @@ const ReviewCardContainer = ({
   mine,
   direction,
 }: ReviewCardContainerProps) => {
-  const { display } = useAppSelector((state) => state.global);
   const { reviewDatas, isLoadingReview, fetchNextPage, hasNextPage } =
     useGetReviews();
 
   return (
-    <ScrollArea
-      veiwportRef={refs?.scrollRef2}
-      ph={20}
-      h={
-        display.height - (mine ? 85 : 35) - globalValue.BOTTOM_NAVIGATION_HEIGHT
-      }
-      style={{ overflow: "hidden" }}
-      onTouchMove={() => {
-        if (
-          direction === "up" &&
-          refs?.scrollRef?.current?.scrollTop >= 332 &&
-          refs?.scrollRef2?.current?.scrollTop === 0
-        ) {
-          refs?.scrollRef.current!.scrollTo({ top: 332 });
-        }
-      }}
-      onScroll={({ scrollY }: onScrollProps) => {
-        // console.log(scrollY);
-        // if (refs?.scrollRef?.current?.scrollTop < 332 && scrollY !== 0) {
-        //   refs?.scrollRef2.current!.style.setProperty("overflow", `hidden`);
-        //   if (direction === "down") {
-        //     // refs?.scrollRef.current!.scrollTo({
-        //     //   top: scrollY,
-        //     // });
-        //   }
-        // }
-      }}
+    <InnerTopNavigation
+      scrollRef={refs?.[0]}
+      innerScrollRef={refs?.[1]}
+      padding={20}
+      bottomHeight={mine ? 85 : 35}
+      direction={direction}
     >
       <ReviewList
         reviewDatas={reviewDatas}
@@ -62,7 +41,7 @@ const ReviewCardContainer = ({
           <Space h={24} />
         </>
       )}
-    </ScrollArea>
+    </InnerTopNavigation>
   );
 };
 

--- a/src/view/Mypage/components/ReviewCardContainer.tsx
+++ b/src/view/Mypage/components/ReviewCardContainer.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { Box, ScrollArea, Space } from "components/core";
+import { onScrollProps } from "components/core/ScrollArea/ScrollArea";
 import LoadingCircle from "components/Loading/LoadingCircle";
 import { globalValue } from "constants/globalValue";
 import useGetReviews from "hooks/queries/user/useGetReviews";
@@ -31,15 +33,23 @@ const ReviewCardContainer = ({
       onTouchMove={() => {
         if (
           direction === "up" &&
-          refs?.scrollRef2?.current?.scrollTop === 0 &&
-          refs?.scrollRef?.current?.scrollTop > 332
+          refs?.scrollRef?.current?.scrollTop >= 332 &&
+          refs?.scrollRef2?.current?.scrollTop === 0
         ) {
           refs?.scrollRef.current!.scrollTo({ top: 332 });
         }
       }}
-      // onScroll={(e: any) => {
-      //   // e.target.scrollTop
-      // }}
+      onScroll={({ scrollY }: onScrollProps) => {
+        // console.log(scrollY);
+        // if (refs?.scrollRef?.current?.scrollTop < 332 && scrollY !== 0) {
+        //   refs?.scrollRef2.current!.style.setProperty("overflow", `hidden`);
+        //   if (direction === "down") {
+        //     // refs?.scrollRef.current!.scrollTo({
+        //     //   top: scrollY,
+        //     // });
+        //   }
+        // }
+      }}
     >
       <ReviewList
         reviewDatas={reviewDatas}

--- a/src/view/SearchPlace/SearchPlace.tsx
+++ b/src/view/SearchPlace/SearchPlace.tsx
@@ -8,7 +8,7 @@ import useDebounce from "hooks/useDebounce";
 import useGetSearch from "hooks/queries/search-places/useGetSearch";
 
 import { colors } from "constants/colors";
-import TopNavigation from "components/TopNavigation";
+import { TopNavigation } from "components/TopNavigation";
 
 import BackTitle from "components/Title/BackTitle";
 import NoneText from "./components/NoneText";

--- a/src/view/StoreDetail/StoreDetail.tsx
+++ b/src/view/StoreDetail/StoreDetail.tsx
@@ -6,7 +6,7 @@ import { keyframes } from "@emotion/react";
 import useDisplaySize from "hooks/useDisplaySize";
 
 import Hashtags from "components/Hashtags";
-import TopNavigation from "components/TopNavigation";
+import { TopNavigation } from "components/TopNavigation";
 import Info from "components/Common/Info";
 
 import { colors } from "constants/colors";


### PR DESCRIPTION
### 목적
TopNavigation 스크롤의 부자연스러운 스크롤을 수정한다

### 할 일
- [x] 1페이지에서 2페이지 넘어갈 때 부자연스러움 발생 
-> 처음 로드될 때, 탭 눌러서 다음 페이지로 넘어가면 부자연스러움이 있음, 본래부터 그런 것으로 판단되어 수정하지 않음
- [x] 1페이지 꼭데기로 올리고 2페이지 스크롤해도 이전 스크롤 유지
- [x] TopNavigation 컴포넌트화 및  코드 정리

### 첨부 이미지
(없음)